### PR TITLE
Handle potential absence of family name in Google Auth

### DIFF
--- a/src/Auth/Method/OAuthGoogle.elm
+++ b/src/Auth/Method/OAuthGoogle.elm
@@ -51,8 +51,22 @@ getUserInfo authenticationSuccess =
         extract : String -> Json.Decoder a -> Dict String Json.Value -> Result String a
         extract k d v =
             Dict.get k v
-                |> Maybe.map (\v_ -> Json.decodeValue d v_ |> Result.mapError Json.errorToString)
+                |> Maybe.map
+                    (\v_ ->
+                        Json.decodeValue d v_
+                            |> Result.mapError Json.errorToString
+                    )
                 |> Maybe.withDefault (Err <| "Key " ++ k ++ " not found")
+
+        extractOptional : a -> String -> Json.Decoder a -> Dict String Json.Value -> Result String a
+        extractOptional default k d v =
+            Dict.get k v
+                |> Maybe.map
+                    (\v_ ->
+                        Json.decodeValue d v_
+                            |> Result.mapError Json.errorToString
+                    )
+                |> Maybe.withDefault (Ok <| default)
 
         tokenR =
             case authenticationSuccess.idJwt of
@@ -86,14 +100,14 @@ getUserInfo authenticationSuccess =
                             (extract "email" Json.string meta)
                             (extract "email_verified" Json.bool meta)
                             (extract "given_name" Json.string meta)
-                            (extract "family_name" Json.string meta)
+                            (extractOptional Nothing "family_name" (Json.string |> Json.nullable) meta)
                     )
     in
     Task.mapError (Auth.Common.ErrAuthString << HttpHelpers.httpErrorToString) <|
         case stuff of
             Ok result ->
                 Task.succeed
-                    { name = result.given_name ++ " " ++ result.family_name
+                    { name = result.given_name ++ " " ++ Maybe.withDefault "" result.family_name
                     , email = result.email
                     , username = Nothing
                     }


### PR DESCRIPTION
If you have Google logins that are just company names, you may not have a family name to be returned from the google auth request. 

This was making it impossible to log in with such accounts. So here we make family name optional.