### PR TITLE
Add auth0 method configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ config =
     , methods =
         [ Auth.Method.EmailMagicLink.configuration
         , Auth.Method.OAuthGithub.configuration Config.githubAppClientId Config.githubAppClientSecret
-        , Auth.Method.OAuthGoogle.configuration Env.googleAppClientId Env.googleAppClientSecret
+        , Auth.Method.OAuthGoogle.configuration Config.googleAppClientId Config.googleAppClientSecret
         ]
     }
 ```

--- a/src/Auth/Common.elm
+++ b/src/Auth/Common.elm
@@ -19,8 +19,6 @@ type alias Config frontendMsg toBackend backendMsg toFrontend frontendModel back
     , sendToBackend : toBackend -> Cmd frontendMsg
     , methods : List (Configuration frontendMsg backendMsg frontendModel backendModel)
     , renewSession : SessionId -> ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
-
-    --, logout : SessionId -> ClientId -> backendModel -> MethodId -> ( backendModel, Cmd backendMsg )
     }
 
 
@@ -103,6 +101,7 @@ type BackendMsg
     | AuthSuccess SessionId ClientId MethodId Time.Posix (Result Error ( UserInfo, Maybe Token ))
     | AuthRenewSession SessionId ClientId
     | AuthLogout SessionId ClientId
+    | AuthDelayedLogout ClientId
 
 
 type ToFrontend

--- a/src/Auth/Common.elm
+++ b/src/Auth/Common.elm
@@ -4,6 +4,7 @@ import Base64.Encode as Base64
 import Browser.Navigation exposing (Key)
 import Bytes exposing (Bytes)
 import Bytes.Encode as Bytes
+import Env
 import OAuth
 import OAuth.AuthorizationCode as OAuth
 import Process
@@ -222,7 +223,7 @@ defaultHttpsUrl =
     }
 
 
-sleepTask isDev msg =
+sleepTask msg =
     -- Because in dev the backendmodel is only persisted every 2 seconds, we need to
     -- make sure we sleep a little before a redirect otherwise we won't have our
     -- persisted state.
@@ -245,3 +246,7 @@ type alias SessionId =
 
 type alias ClientId =
     String
+
+
+isDev =
+    Env.mode == Env.Development

--- a/src/Auth/Common.elm
+++ b/src/Auth/Common.elm
@@ -222,15 +222,17 @@ defaultHttpsUrl =
     }
 
 
-sleepIfDevForBackendPersistence isDev =
+sleepTask isDev msg =
     -- Because in dev the backendmodel is only persisted every 2 seconds, we need to
     -- make sure we sleep a little before a redirect otherwise we won't have our
     -- persisted state.
-    if isDev then
+    (if isDev then
         Process.sleep 3000
 
-    else
+     else
         Process.sleep 0
+    )
+        |> Task.perform (always msg)
 
 
 

--- a/src/Auth/Common.elm
+++ b/src/Auth/Common.elm
@@ -4,15 +4,11 @@ import Base64.Encode as Base64
 import Browser.Navigation exposing (Key)
 import Bytes exposing (Bytes)
 import Bytes.Encode as Bytes
-import Dict exposing (Dict)
-import Http
-import Json.Decode as Json
 import OAuth
 import OAuth.AuthorizationCode as OAuth
 import Task exposing (Task)
 import Time
 import Url exposing (Protocol(..), Url)
-import Url.Builder
 
 
 type alias Config frontendMsg toBackend backendMsg toFrontend frontendModel backendModel =
@@ -23,7 +19,8 @@ type alias Config frontendMsg toBackend backendMsg toFrontend frontendModel back
     , sendToBackend : toBackend -> Cmd frontendMsg
     , methods : List (Configuration frontendMsg backendMsg frontendModel backendModel)
     , renewSession : SessionId -> ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
-    , logout : SessionId -> ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
+
+    --, logout : SessionId -> ClientId -> backendModel -> MethodId -> ( backendModel, Cmd backendMsg )
     }
 
 
@@ -66,6 +63,7 @@ type alias ConfigurationOAuth frontendMsg backendMsg frontendModel backendModel 
     { id : String
     , authorizationEndpoint : Url
     , tokenEndpoint : Url
+    , logoutEndpoint : Maybe Url
     , clientId : String
 
     -- @TODO this will force a leak out as frontend uses this config?
@@ -104,12 +102,15 @@ type BackendMsg
     | AuthCallbackReceived_ SessionId ClientId MethodId Url String String Time.Posix
     | AuthSuccess SessionId ClientId MethodId Time.Posix (Result Error ( UserInfo, Maybe Token ))
     | AuthRenewSession SessionId ClientId
+    | AuthLogout SessionId ClientId
 
 
 type ToFrontend
     = AuthInitiateSignin Url
     | AuthError Error
     | AuthSessionChallenge AuthChallengeReason
+    | AuthSetLogoutUrl (Maybe Url)
+    | AuthSignOut
 
 
 type AuthChallengeReason

--- a/src/Auth/Common.elm
+++ b/src/Auth/Common.elm
@@ -6,6 +6,7 @@ import Bytes exposing (Bytes)
 import Bytes.Encode as Bytes
 import OAuth
 import OAuth.AuthorizationCode as OAuth
+import Process
 import Task exposing (Task)
 import Time
 import Url exposing (Protocol(..), Url)
@@ -219,6 +220,17 @@ defaultHttpsUrl =
     , query = Nothing
     , fragment = Nothing
     }
+
+
+sleepIfDevForBackendPersistence isDev =
+    -- Because in dev the backendmodel is only persisted every 2 seconds, we need to
+    -- make sure we sleep a little before a redirect otherwise we won't have our
+    -- persisted state.
+    if isDev then
+        Process.sleep 3000
+
+    else
+        Process.sleep 0
 
 
 

--- a/src/Auth/Common.elm
+++ b/src/Auth/Common.elm
@@ -109,7 +109,7 @@ type ToFrontend
     = AuthInitiateSignin Url
     | AuthError Error
     | AuthSessionChallenge AuthChallengeReason
-    | AuthSetLogoutUrl (Maybe Url)
+    | AuthSetMethodId MethodId
     | AuthSignOut
 
 
@@ -132,6 +132,7 @@ type Provider
     = EmailMagicLink
     | OAuthGithub
     | OAuthGoogle
+    | OAuthAuth0
 
 
 type Flow

--- a/src/Auth/Flow.elm
+++ b/src/Auth/Flow.elm
@@ -1,6 +1,6 @@
 module Auth.Flow exposing (..)
 
-import Auth.Common
+import Auth.Common exposing (MethodId)
 import Auth.Method.EmailMagicLink
 import Auth.Method.OAuthGithub
 import Auth.Method.OAuthGoogle
@@ -119,7 +119,7 @@ type alias BackendUpdateConfig frontendMsg backendMsg toFrontend frontendModel b
         Auth.Common.SessionId
         -> Auth.Common.ClientId
         -> Auth.Common.UserInfo
-        -> Maybe Url
+        -> MethodId
         -> Maybe Auth.Common.Token
         -> Time.Posix
         -> ( { backendModel | pendingAuths : Dict Auth.Common.SessionId Auth.Common.PendingAuth }, Cmd backendMsg )
@@ -185,21 +185,13 @@ backendUpdate { asToFrontend, asBackendMsg, sendToFrontend, backendModel, loadMe
             let
                 removeSession backendModel_ =
                     { backendModel_ | pendingAuths = backendModel_.pendingAuths |> Dict.remove sessionId }
-
-                authLogoutUrl method =
-                    case method of
-                        Auth.Common.ProtocolEmailMagicLink _ ->
-                            Nothing
-
-                        Auth.Common.ProtocolOAuth config ->
-                            config.logoutEndpoint
             in
             withMethod methodId
                 clientId
                 (\method ->
                     case res of
                         Ok ( userInfo, authToken ) ->
-                            handleAuthSuccess sessionId clientId userInfo (authLogoutUrl method) authToken now
+                            handleAuthSuccess sessionId clientId userInfo methodId authToken now
                                 |> Tuple.mapFirst removeSession
 
                         Err err ->

--- a/src/Auth/Flow.elm
+++ b/src/Auth/Flow.elm
@@ -125,7 +125,8 @@ type alias BackendUpdateConfig frontendMsg backendMsg toFrontend frontendModel b
         -> ( { backendModel | pendingAuths : Dict Auth.Common.SessionId Auth.Common.PendingAuth }, Cmd backendMsg )
     , isDev : Bool
     , renewSession : Auth.Common.SessionId -> Auth.Common.ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
-    , logout : Auth.Common.SessionId -> Auth.Common.ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
+    , logout : Auth.Common.SessionId -> Auth.Common.ClientId -> Bool -> backendModel -> ( backendModel, Cmd backendMsg )
+    , logoutDelayed : Auth.Common.ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
     }
 
 
@@ -138,7 +139,7 @@ backendUpdate :
         { backendModel | pendingAuths : Dict Auth.Common.SessionId Auth.Common.PendingAuth }
     -> Auth.Common.BackendMsg
     -> ( { backendModel | pendingAuths : Dict Auth.Common.SessionId Auth.Common.PendingAuth }, Cmd backendMsg )
-backendUpdate { asToFrontend, asBackendMsg, sendToFrontend, backendModel, loadMethod, handleAuthSuccess, isDev, renewSession, logout } authBackendMsg =
+backendUpdate { asToFrontend, asBackendMsg, sendToFrontend, backendModel, loadMethod, handleAuthSuccess, isDev, renewSession, logout, logoutDelayed } authBackendMsg =
     let
         authError str =
             asToFrontend (Auth.Common.AuthError (Auth.Common.ErrAuthString str))
@@ -202,7 +203,10 @@ backendUpdate { asToFrontend, asBackendMsg, sendToFrontend, backendModel, loadMe
             renewSession sessionId clientId backendModel
 
         Auth.Common.AuthLogout sessionId clientId ->
-            logout sessionId clientId backendModel
+            logout sessionId clientId isDev backendModel
+
+        Auth.Common.AuthDelayedLogout clientId ->
+            logoutDelayed clientId backendModel
 
 
 signInRequested :

--- a/src/Auth/Flow.elm
+++ b/src/Auth/Flow.elm
@@ -301,3 +301,11 @@ findMethod :
     -> Maybe (Auth.Common.Configuration frontendMsg backendMsg frontendModel backendModel)
 findMethod methodId config =
     methodLoader config.methods methodId
+
+
+logoutRequest isDev logoutMsg =
+    Auth.Common.sleepTask isDev logoutMsg
+
+
+logoutRequestDelayed delayedLogoutMsg =
+    delayedLogoutMsg

--- a/src/Auth/Flow.elm
+++ b/src/Auth/Flow.elm
@@ -123,9 +123,8 @@ type alias BackendUpdateConfig frontendMsg backendMsg toFrontend frontendModel b
         -> Maybe Auth.Common.Token
         -> Time.Posix
         -> ( { backendModel | pendingAuths : Dict Auth.Common.SessionId Auth.Common.PendingAuth }, Cmd backendMsg )
-    , isDev : Bool
     , renewSession : Auth.Common.SessionId -> Auth.Common.ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
-    , logout : Auth.Common.SessionId -> Auth.Common.ClientId -> Bool -> backendModel -> ( backendModel, Cmd backendMsg )
+    , logout : Auth.Common.SessionId -> Auth.Common.ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
     , logoutDelayed : Auth.Common.ClientId -> backendModel -> ( backendModel, Cmd backendMsg )
     }
 
@@ -139,7 +138,7 @@ backendUpdate :
         { backendModel | pendingAuths : Dict Auth.Common.SessionId Auth.Common.PendingAuth }
     -> Auth.Common.BackendMsg
     -> ( { backendModel | pendingAuths : Dict Auth.Common.SessionId Auth.Common.PendingAuth }, Cmd backendMsg )
-backendUpdate { asToFrontend, asBackendMsg, sendToFrontend, backendModel, loadMethod, handleAuthSuccess, isDev, renewSession, logout, logoutDelayed } authBackendMsg =
+backendUpdate { asToFrontend, asBackendMsg, sendToFrontend, backendModel, loadMethod, handleAuthSuccess, renewSession, logout, logoutDelayed } authBackendMsg =
     let
         authError str =
             asToFrontend (Auth.Common.AuthError (Auth.Common.ErrAuthString str))
@@ -164,7 +163,7 @@ backendUpdate { asToFrontend, asBackendMsg, sendToFrontend, backendModel, loadMe
                             config.initiateSignin sessionId clientId backendModel { username = username } now
 
                         Auth.Common.ProtocolOAuth config ->
-                            Auth.Protocol.OAuth.initiateSignin sessionId baseUrl config isDev asBackendMsg now backendModel
+                            Auth.Protocol.OAuth.initiateSignin sessionId baseUrl config asBackendMsg now backendModel
                 )
 
         Auth.Common.AuthSigninInitiatedDelayed_ sessionId initiateMsg ->
@@ -203,7 +202,7 @@ backendUpdate { asToFrontend, asBackendMsg, sendToFrontend, backendModel, loadMe
             renewSession sessionId clientId backendModel
 
         Auth.Common.AuthLogout sessionId clientId ->
-            logout sessionId clientId isDev backendModel
+            logout sessionId clientId backendModel
 
         Auth.Common.AuthDelayedLogout clientId ->
             logoutDelayed clientId backendModel
@@ -303,8 +302,8 @@ findMethod methodId config =
     methodLoader config.methods methodId
 
 
-logoutRequest isDev logoutMsg =
-    Auth.Common.sleepTask isDev logoutMsg
+logoutRequest logoutMsg =
+    Auth.Common.sleepTask logoutMsg
 
 
 logoutRequestDelayed delayedLogoutMsg =

--- a/src/Auth/Method/OAuthAuth0.elm
+++ b/src/Auth/Method/OAuthAuth0.elm
@@ -5,6 +5,7 @@ import Auth.Protocol.OAuth
 import Base64.Encode as Base64
 import Bytes exposing (Bytes)
 import Bytes.Encode as Bytes
+import Config
 import Dict exposing (Dict)
 import Env exposing (..)
 import Http
@@ -31,9 +32,9 @@ configuration :
 configuration clientId clientSecret =
     ProtocolOAuth
         { id = "OAuthAuth0"
-        , authorizationEndpoint = { defaultHttpsUrl | host = Env.auth0AppTenant, path = "/authorize" }
-        , tokenEndpoint = { defaultHttpsUrl | host = Env.auth0AppTenant, path = "/oauth/token" }
-        , logoutEndpoint = Just { defaultHttpsUrl | host = Env.auth0AppTenant, path = "/v2/logout", query = Just ("client_id=" ++ clientId ++ "&returnTo=") }
+        , authorizationEndpoint = { defaultHttpsUrl | host = Config.auth0AppTenant, path = "/authorize" }
+        , tokenEndpoint = { defaultHttpsUrl | host = Config.auth0AppTenant, path = "/oauth/token" }
+        , logoutEndpoint = Just { defaultHttpsUrl | host = Config.auth0AppTenant, path = "/v2/logout", query = Just ("client_id=" ++ clientId ++ "&returnTo=") }
         , clientId = clientId
         , clientSecret = clientSecret
         , scope = [ "openid email profile" ]

--- a/src/Auth/Method/OAuthGithub.elm
+++ b/src/Auth/Method/OAuthGithub.elm
@@ -31,6 +31,7 @@ configuration clientId clientSecret =
         { id = "OAuthGithub"
         , authorizationEndpoint = { defaultHttpsUrl | host = "github.com", path = "/login/oauth/authorize" }
         , tokenEndpoint = { defaultHttpsUrl | host = "github.com", path = "/login/oauth/access_token" }
+        , logoutEndpoint = Nothing
         , clientId = clientId
         , clientSecret = clientSecret
         , scope = [ "read:user", "user:email" ]

--- a/src/Auth/Protocol/OAuth.elm
+++ b/src/Auth/Protocol/OAuth.elm
@@ -92,15 +92,14 @@ initiateSignin sessionId baseUrl config isDev asBackendMsg now backendModel =
     ( { backendModel
         | pendingAuths = backendModel.pendingAuths |> Dict.insert sessionId newPendingAuth
       }
-    , Auth.Common.sleepIfDevForBackendPersistence isDev
-        |> Task.perform
-            (always
-                (AuthSigninInitiatedDelayed_
-                    sessionId
-                    (AuthInitiateSignin url)
-                )
+    , Auth.Common.sleepTask
+        isDev
+        (asBackendMsg
+            (AuthSigninInitiatedDelayed_
+                sessionId
+                (AuthInitiateSignin url)
             )
-        |> Cmd.map asBackendMsg
+        )
     )
 
 

--- a/src/Auth/Protocol/OAuth.elm
+++ b/src/Auth/Protocol/OAuth.elm
@@ -70,7 +70,7 @@ accessTokenRequested model methodId code state =
     )
 
 
-initiateSignin sessionId baseUrl config isDev asBackendMsg now backendModel =
+initiateSignin sessionId baseUrl config asBackendMsg now backendModel =
     let
         signedState =
             SHA1.toBase64 <|
@@ -93,7 +93,6 @@ initiateSignin sessionId baseUrl config isDev asBackendMsg now backendModel =
         | pendingAuths = backendModel.pendingAuths |> Dict.insert sessionId newPendingAuth
       }
     , Auth.Common.sleepTask
-        isDev
         (asBackendMsg
             (AuthSigninInitiatedDelayed_
                 sessionId

--- a/src/Auth/Protocol/OAuth.elm
+++ b/src/Auth/Protocol/OAuth.elm
@@ -88,21 +88,11 @@ initiateSignin sessionId baseUrl config isDev asBackendMsg now backendModel =
 
         url =
             generateSigninUrl baseUrl signedState config
-
-        sleepIfDevForBackendPersistence =
-            -- Because in dev the backendmodel is only persisted every 2 seconds, we need to
-            -- make sure we sleep a little before a redirect otherwise we won't have our
-            -- peristed state.
-            if isDev then
-                Process.sleep 3000
-
-            else
-                Process.sleep 0
     in
     ( { backendModel
         | pendingAuths = backendModel.pendingAuths |> Dict.insert sessionId newPendingAuth
       }
-    , sleepIfDevForBackendPersistence
+    , Auth.Common.sleepIfDevForBackendPersistence isDev
         |> Task.perform
             (always
                 (AuthSigninInitiatedDelayed_


### PR DESCRIPTION
- Adds 0AuthAuth0 config for Auth0 to enable username/password as well as Auth0 social connectors.
- Handles redirect logout url, and dev persistence delay for it, since such logout is required for username/password
- This commit does not explore the possible fields returned besides email from the various social connectors within Auth0. Only email is left as mandatory.
