### PR TITLE
Sign out requested

### DIFF
--- a/src/Auth/Common.elm
+++ b/src/Auth/Common.elm
@@ -37,7 +37,6 @@ type alias ConfigurationEmailMagicLink frontendMsg backendMsg frontendModel back
         SessionId
         -> ClientId
         -> backendModel
-        -> Bool
         -> { username : Maybe String }
         -> Time.Posix
         -> ( backendModel, Cmd backendMsg )

--- a/src/Auth/Common.elm
+++ b/src/Auth/Common.elm
@@ -14,7 +14,6 @@ import Process
 import Task exposing (Task)
 import Time
 import Url exposing (Protocol(..), Url)
-import Url.Builder
 
 
 type alias Config frontendMsg toBackend backendMsg toFrontend frontendModel backendModel =
@@ -68,6 +67,7 @@ type alias ConfigurationOAuth frontendMsg backendMsg frontendModel backendModel 
     , authorizationEndpoint : Url
     , tokenEndpoint : Url
     , logoutEndpoint : LogoutEndpointConfig
+    , allowLoginQueryParameters : Bool
     , clientId : String
 
     -- @TODO this will force a leak out as frontend uses this config?

--- a/src/Auth/Flow.elm
+++ b/src/Auth/Flow.elm
@@ -237,6 +237,7 @@ signOutRequested maybeUrlConfig callBackQueries model =
             Navigation.load <|
                 Url.toString model.authLogoutReturnUrlBase
                     ++ homeUrlConfig.returnPath
+                    ++ Url.Builder.toQuery callBackQueries
 
         Nothing ->
             Navigation.load <|

--- a/src/Auth/Flow.elm
+++ b/src/Auth/Flow.elm
@@ -49,11 +49,8 @@ init model methodId origin navigationKey toBackendFn =
             )
 
 
-onFrontendLogoutCallback navigationMsg toBackendFn =
-    Cmd.batch
-        [ toBackendFn AuthLogoutRequested
-        , navigationMsg
-        ]
+onFrontendLogoutCallback navigationMsg =
+    navigationMsg
 
 
 updateFromFrontend { asBackendMsg } clientId sessionId authToBackend model =

--- a/src/Auth/Method/EmailMagicLink.elm
+++ b/src/Auth/Method/EmailMagicLink.elm
@@ -23,7 +23,6 @@ configuration :
         SessionId
         -> ClientId
         -> backendModel
-        -> Bool
         -> { username : Maybe String }
         -> Time.Posix
         -> ( backendModel, Cmd backendMsg )

--- a/src/Auth/Method/OAuthAuth0.elm
+++ b/src/Auth/Method/OAuthAuth0.elm
@@ -41,6 +41,7 @@ configuration clientId clientSecret appTenant =
                     }
                 , returnPath = "/logout/OAuthAuth0/callback"
                 }
+        , allowLoginQueryParameters = True
         , clientId = clientId
         , clientSecret = clientSecret
         , scope = [ "openid email profile" ]

--- a/src/Auth/Method/OAuthGithub.elm
+++ b/src/Auth/Method/OAuthGithub.elm
@@ -33,6 +33,7 @@ configuration clientId clientSecret =
         , authorizationEndpoint = { defaultHttpsUrl | host = "github.com", path = "/login/oauth/authorize" }
         , tokenEndpoint = { defaultHttpsUrl | host = "github.com", path = "/login/oauth/access_token" }
         , logoutEndpoint = Home { returnPath = "/logout/OAuthGithub/callback" }
+        , allowLoginQueryParameters = True
         , clientId = clientId
         , clientSecret = clientSecret
         , scope = [ "read:user", "user:email" ]

--- a/src/Auth/Method/OAuthGoogle.elm
+++ b/src/Auth/Method/OAuthGoogle.elm
@@ -33,6 +33,7 @@ configuration clientId clientSecret =
         , authorizationEndpoint = { defaultHttpsUrl | host = "accounts.google.com", path = "/o/oauth2/v2/auth" }
         , tokenEndpoint = { defaultHttpsUrl | host = "oauth2.googleapis.com", path = "/token" }
         , logoutEndpoint = Home { returnPath = "/logout/OAuthGoogle/callback" }
+        , allowLoginQueryParameters = False
         , clientId = clientId
         , clientSecret = clientSecret
         , scope = [ "openid email profile" ]

--- a/src/Auth/Protocol/OAuth.elm
+++ b/src/Auth/Protocol/OAuth.elm
@@ -6,7 +6,6 @@ import Browser.Navigation as Navigation
 import Dict exposing (Dict)
 import Http
 import Json.Decode as Json
-import List.Extra as List
 import OAuth
 import OAuth.AuthorizationCode as OAuth
 import Process
@@ -108,6 +107,7 @@ generateSigninUrl : Url -> Auth.Common.State -> Auth.Common.ConfigurationOAuth f
 generateSigninUrl baseUrl state configuration =
     let
         queryAdjustedUrl =
+            -- google auth is an example where, at time of writing, query parameters are not allowed in a login redirect url
             if configuration.allowLoginQueryParameters then
                 baseUrl
 

--- a/src/Auth/Protocol/OAuth.elm
+++ b/src/Auth/Protocol/OAuth.elm
@@ -11,6 +11,7 @@ import OAuth
 import OAuth.AuthorizationCode as OAuth
 import Process
 import SHA1
+import Share.Config exposing (isDev)
 import Task exposing (Task)
 import Time
 import Url exposing (Url)
@@ -70,7 +71,7 @@ accessTokenRequested model methodId code state =
     )
 
 
-initiateSignin sessionId baseUrl isDev config asBackendMsg now backendModel =
+initiateSignin sessionId baseUrl config asBackendMsg now backendModel =
     let
         signedState =
             SHA1.toBase64 <|
@@ -92,7 +93,8 @@ initiateSignin sessionId baseUrl isDev config asBackendMsg now backendModel =
     ( { backendModel
         | pendingAuths = backendModel.pendingAuths |> Dict.insert sessionId newPendingAuth
       }
-    , Auth.Common.sleepTask isDev
+    , Auth.Common.sleepTask
+        isDev
         (asBackendMsg
             (AuthSigninInitiatedDelayed_
                 sessionId
@@ -105,9 +107,16 @@ initiateSignin sessionId baseUrl isDev config asBackendMsg now backendModel =
 generateSigninUrl : Url -> Auth.Common.State -> Auth.Common.ConfigurationOAuth frontendMsg backendMsg frontendModel backendModel -> Url
 generateSigninUrl baseUrl state configuration =
     let
+        queryAdjustedUrl =
+            if configuration.allowLoginQueryParameters then
+                baseUrl
+
+            else
+                { baseUrl | query = Nothing }
+
         authorization =
             { clientId = configuration.clientId
-            , redirectUri = baseUrl |> (\v -> { v | path = "/login/" ++ configuration.id ++ "/callback" })
+            , redirectUri = { queryAdjustedUrl | path = "/login/" ++ configuration.id ++ "/callback" }
             , scope = configuration.scope
             , state = Just state
             , url = configuration.authorizationEndpoint


### PR DESCRIPTION
Google oauth doesn’t allow query parameters on a return login or logout url. So have added a config bool to remove them.

signoutRequested is back, navigating to a return url according to configuration options previously added.